### PR TITLE
feat(toggleable): add toggleable property to uiSchema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-web-jsonschema-form",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": false,
   "main": "index.js",
   "scripts": {

--- a/src/fields/AbstractField.js
+++ b/src/fields/AbstractField.js
@@ -34,6 +34,7 @@ class AbstractField extends React.Component {
     noTitle: PropTypes.bool,
     titleOnly: PropTypes.bool,
     zIndex: PropTypes.number,
+    meta: PropTypes.any, // eslint-disable-line
     errors: PropTypes.any, // eslint-disable-line
     value: PropTypes.any, // eslint-disable-line
   };
@@ -85,12 +86,13 @@ class AbstractField extends React.Component {
       noTitle,
       required,
     } = this.props;
-    if (
+    const hasTitle = !(
       noTitle
       || uiSchema['ui:title'] === false
       || schema.type === 'object'
       || schema.type === 'array'
-    ) {
+    );
+    if (!uiSchema['ui:toggleable'] && !hasTitle) {
       return null;
     }
     const { LabelWidget } = widgets;
@@ -99,7 +101,14 @@ class AbstractField extends React.Component {
       title += '*';
     }
     return (
-      <LabelWidget hasError={hasError} auto={uiSchema['ui:inline']} {...(uiSchema['ui:titleProps'] || {})}>
+      <LabelWidget
+        {...this.props}
+        toggleable={!!uiSchema['ui:toggleable']}
+        hasTitle={hasTitle}
+        hasError={hasError}
+        auto={uiSchema['ui:inline']}
+        {...(uiSchema['ui:titleProps'] || {})}
+      >
         {title}
       </LabelWidget>
     );
@@ -109,6 +118,7 @@ class AbstractField extends React.Component {
     const {
       id,
       name,
+      meta,
       schema,
       uiSchema,
       widgets,
@@ -180,7 +190,7 @@ class AbstractField extends React.Component {
               auto={uiSchema['ui:inline']}
               hasError={hasError}
               placeholder={placeholder}
-              disabled={!!uiSchema['ui:disabled']}
+              disabled={!!(meta && meta['ui:disabled'])}
               readonly={!!uiSchema['ui:readonly']}
               {...(uiSchema['ui:widgetProps'] || {})}
             />

--- a/src/utils.js
+++ b/src/utils.js
@@ -185,19 +185,37 @@ export const merge = (destination, source = {}) => {
   return destination;
 };
 
-export const getValues = (data, schema, key, casting = true, meta = false) => {
+export const getValues = (data, schema, key, casting = true, uiSchema = false) => {
   let value = key ? get(data, key) : data;
   if (schema.type === 'object') {
     value = isPlainObject(value) ? value : {};
     const node = {};
     each(schema.properties, (propertySchema, propertyKey) => {
-      node[propertyKey] = getValues(value, propertySchema, propertyKey, casting, meta);
+      node[propertyKey] = getValues(
+        value,
+        propertySchema,
+        propertyKey,
+        casting,
+        uiSchema && uiSchema[propertyKey],
+      );
     });
+    if (uiSchema) {
+      value['ui:disabled'] = (uiSchema && uiSchema['ui:disabled']) || false;
+    }
     return node;
   }
   if (schema.type === 'array') {
     value = isArray(value) ? value : [];
-    return value.map(item => getValues(item, schema.items, null, casting, meta));
+    if (uiSchema) {
+      value['ui:disabled'] = (uiSchema && uiSchema['ui:disabled']) || false;
+    }
+    return value.map(item => getValues(
+      item,
+      schema.items,
+      null,
+      casting,
+      uiSchema && uiSchema.items,
+    ));
   }
   if (casting) {
     if (value === null || value === undefined) {
@@ -219,13 +237,15 @@ export const getValues = (data, schema, key, casting = true, meta = false) => {
         default: break;
       }
     }
-  } else if (meta) {
-    value = {};
+  } else if (uiSchema) {
+    value = {
+      'ui:disabled': (uiSchema && uiSchema['ui:disabled']) || false,
+    };
   }
   return value;
 };
 
-export const getMeta = (data, schema, key) => getValues(data, schema, key, false, true);
+export const getMeta = (data, schema, uiSchema) => getValues(data, schema, null, false, uiSchema);
 
 export const getErrors = (data, schema, key) => getValues(data, schema, key, false);
 
@@ -348,3 +368,147 @@ export const normalized = (value) => {
   }
   return value;
 };
+
+export const viewStyleKeys = [
+  'animationDelay',
+  'animationDirection',
+  'animationDuration',
+  'animationFillMode',
+  'animationIterationCount',
+  'animationName',
+  'animationPlayState',
+  'animationTimingFunction',
+  'transitionDelay',
+  'transitionDuration',
+  'transitionProperty',
+  'transitionTimingFunction',
+  'borderColor',
+  'borderBottomColor',
+  'borderEndColor',
+  'borderLeftColor',
+  'borderRightColor',
+  'borderStartColor',
+  'borderTopColor',
+  'borderRadius',
+  'borderBottomEndRadius',
+  'borderBottomLeftRadius',
+  'borderBottomRightRadius',
+  'borderBottomStartRadius',
+  'borderTopEndRadius',
+  'borderTopLeftRadius',
+  'borderTopRightRadius',
+  'borderTopStartRadius',
+  'borderStyle',
+  'borderBottomStyle',
+  'borderEndStyle',
+  'borderLeftStyle',
+  'borderRightStyle',
+  'borderStartStyle',
+  'borderTopStyle',
+  'cursor',
+  'touchAction',
+  'userSelect',
+  'willChange',
+  'alignContent',
+  'alignItems',
+  'alignSelf',
+  'backfaceVisibility',
+  'borderWidth',
+  'borderBottomWidth',
+  'borderEndWidth',
+  'borderLeftWidth',
+  'borderRightWidth',
+  'borderStartWidth',
+  'borderTopWidth',
+  'bottom',
+  'boxSizing',
+  'direction',
+  'display',
+  'end',
+  'flex',
+  'flexBasis',
+  'flexDirection',
+  'flexGrow',
+  'flexShrink',
+  'flexWrap',
+  'height',
+  'justifyContent',
+  'left',
+  'margin',
+  'marginBottom',
+  'marginHorizontal',
+  'marginEnd',
+  'marginLeft',
+  'marginRight',
+  'marginStart',
+  'marginTop',
+  'marginVertical',
+  'maxHeight',
+  'maxWidth',
+  'minHeight',
+  'minWidth',
+  'order',
+  'overflow',
+  'overflowX',
+  'overflowY',
+  'padding',
+  'paddingBottom',
+  'paddingHorizontal',
+  'paddingEnd',
+  'paddingLeft',
+  'paddingRight',
+  'paddingStart',
+  'paddingTop',
+  'paddingVertical',
+  'position',
+  'right',
+  'start',
+  'top',
+  'visibility',
+  'width',
+  'zIndex',
+  'aspectRatio',
+  'gridAutoColumns',
+  'gridAutoFlow',
+  'gridAutoRows',
+  'gridColumnEnd',
+  'gridColumnGap',
+  'gridColumnStart',
+  'gridRowEnd',
+  'gridRowGap',
+  'gridRowStart',
+  'gridTemplateColumns',
+  'gridTemplateRows',
+  'gridTemplateAreas',
+  'shadowColor',
+  'shadowOffset',
+  'shadowOpacity',
+  'shadowRadius',
+  'shadowSpread',
+  'perspective',
+  'perspectiveOrigin',
+  'transform',
+  'transformOrigin',
+  'transformStyle',
+  'backgroundColor',
+  'opacity',
+  'elevation',
+  'backgroundAttachment',
+  'backgroundBlendMode',
+  'backgroundClip',
+  'backgroundImage',
+  'backgroundOrigin',
+  'backgroundPosition',
+  'backgroundRepeat',
+  'backgroundSize',
+  'boxShadow',
+  'clip',
+  'filter',
+  'outline',
+  'outlineColor',
+  'overscrollBehavior',
+  'overscrollBehaviorX',
+  'overscrollBehaviorY',
+  'WebkitMaskImage',
+  'WebkitOverflowScrolling',
+];

--- a/src/widgets/ArrayWidget/index.js
+++ b/src/widgets/ArrayWidget/index.js
@@ -226,11 +226,19 @@ const ArrayWidget = compose(
   } = props;
   const { LabelWidget } = widgets;
   const hasError = isArray(errors) && errors.length > 0 && !errors.hidden;
-
+  const hasTitle = uiSchema['ui:title'] !== false;
+  const toggleable = !!uiSchema['ui:toggleable'];
   return (
     <React.Fragment>
-      {uiSchema['ui:title'] !== false ? (
-        <LabelWidget hasError={hasError} auto={uiSchema['ui:inline']} {...uiSchema['ui:titleProps']}>
+      {hasTitle || toggleable ? (
+        <LabelWidget
+          {...this.props}
+          toggleable={toggleable}
+          hasTitle={hasTitle}
+          hasError={hasError}
+          auto={uiSchema['ui:inline']}
+          {...uiSchema['ui:titleProps']}
+        >
           {title}
         </LabelWidget>
       ) : null}

--- a/src/widgets/CheckboxWidget.js
+++ b/src/widgets/CheckboxWidget.js
@@ -61,7 +61,14 @@ const CheckboxWidget = withHandlers({
   if (gridItemType !== 'grid' || gridItemLength <= 1 || Screen.getType() === 'xs') {
     css.push(styles.alone);
   }
-  if (adjustTitle && gridItemType === 'grid' && gridItemLength > 1 && Screen.getType() !== 'xs' && uiSchema['ui:title'] === false) {
+  if (
+    adjustTitle
+    && gridItemType === 'grid'
+    && gridItemLength > 1
+    && Screen.getType() !== 'xs'
+    && uiSchema['ui:title'] === false
+    && !uiSchema['ui:toggleable']
+  ) {
     css.push(styles.adjustTitle);
   }
   css.push(auto ? styles.auto : styles.fullWidth);

--- a/src/widgets/FileWidget/index.js
+++ b/src/widgets/FileWidget/index.js
@@ -580,8 +580,15 @@ const FileWidget = compose(
   ...props
 }) => (
   <React.Fragment>
-    {title !== false ? (
-      <LabelWidget hasError={hasError} auto={propertyUiSchema['ui:inline']} {...propertyUiSchema['ui:titleProps']}>
+    {title !== false || uiSchema['ui:toggleable'] ? (
+      <LabelWidget
+        {...props}
+        toggleable={!!uiSchema['ui:toggleable']}
+        hasTitle={title !== false}
+        hasError={hasError}
+        auto={propertyUiSchema['ui:inline']}
+        {...propertyUiSchema['ui:titleProps']}
+      >
         {title}
       </LabelWidget>
     ) : null}

--- a/src/widgets/LabelWidget.js
+++ b/src/widgets/LabelWidget.js
@@ -1,54 +1,124 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { StyleSheet } from 'react-native';
+import { pick, omit } from 'lodash';
+import { withHandlers, compose } from 'recompact';
 import { withTheme } from 'react-native-web-ui-components/Theme';
+import View from 'react-native-web-ui-components/View';
 import Text from 'react-native-web-ui-components/Text';
+import Checkbox from 'react-native-web-ui-components/Checkbox';
 import StylePropType from 'react-native-web-ui-components/StylePropType';
+import { viewStyleKeys } from '../utils';
 
 const styles = StyleSheet.create({
-  defaults: {},
   error: {
     color: '#EE2D68',
   },
-  label: {
-    fontWeight: 'bold',
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  labelContainer: {
     paddingTop: 10,
     paddingBottom: 5,
   },
+  labelText: {
+    fontWeight: 'bold',
+  },
+  checkbox: {
+    height: 20,
+    marginRight: 5,
+  },
+  checkboxIcon: {
+    fontSize: 20,
+    height: 20,
+    lineHeight: 20,
+  },
+  fullWidth: {
+    width: '100%',
+  },
 });
 
-const LabelWidget = ({
+const LabelWidget = compose(
+  withHandlers({
+    onPress: ({
+      name,
+      meta,
+      value,
+      onChange,
+    }) => checked => onChange(value, name, {
+      nextMeta: { ...meta, 'ui:disabled': !!checked },
+    }),
+  }),
+)(({
+  children,
   theme,
   themeTextStyle,
   style,
   hasError,
   label,
-  ...props
+  meta,
+  auto,
+  hasTitle,
+  toggleable,
+  onPress,
 }) => {
-  const currentStyle = [styles.defaults];
+  const currentContainerStyle = [
+    styles.container,
+    auto ? null : styles.fullWidth,
+  ];
+  const currentTextStyle = [];
   if (label) {
-    currentStyle.push(styles.label);
+    currentContainerStyle.push(styles.labelContainer);
+    currentTextStyle.push(styles.labelText);
   }
   if (hasError) {
-    currentStyle.push({ color: StyleSheet.flatten(theme.input.error.border).borderColor });
+    currentTextStyle.push({ color: StyleSheet.flatten(theme.input.error.border).borderColor });
   } else {
-    currentStyle.push(themeTextStyle.text);
+    currentTextStyle.push(themeTextStyle.text);
   }
-  currentStyle.push(style);
-  return <Text {...props} style={currentStyle} />;
-};
+  const css = StyleSheet.flatten(style || {});
+  return (
+    <View style={[currentContainerStyle, pick(css, viewStyleKeys)]}>
+      {toggleable ? (
+        <Checkbox
+          text={null}
+          checked={!(meta && meta['ui:disabled'])}
+          value
+          auto
+          style={styles.checkbox}
+          styleChecked={styles.checkboxIcon}
+          styleUnchecked={styles.checkboxIcon}
+          onPress={onPress}
+        />
+      ) : null}
+      {hasTitle ? (
+        <Text auto style={[currentTextStyle, omit(css, viewStyleKeys)]}>
+          {children}
+        </Text>
+      ) : null}
+    </View>
+  );
+});
 
 LabelWidget.propTypes = {
   theme: PropTypes.shape().isRequired,
   themeTextStyle: PropTypes.shape().isRequired,
+  name: PropTypes.string.isRequired,
   hasError: PropTypes.bool.isRequired,
+  hasTitle: PropTypes.bool.isRequired,
+  toggleable: PropTypes.bool.isRequired,
+  children: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   style: StylePropType,
   label: PropTypes.bool,
+  auto: PropTypes.bool,
+  meta: PropTypes.any, // eslint-disable-line
 };
 
 LabelWidget.defaultProps = {
   style: null,
   label: false,
+  auto: false,
 };
 
 export default withTheme('LabelWidget')(LabelWidget);

--- a/src/widgets/ObjectWidget/createGrid.js
+++ b/src/widgets/ObjectWidget/createGrid.js
@@ -111,10 +111,13 @@ const createGridItem = (
   const { widgets } = params;
   if (gridItem.type === 'label') {
     const Widget = widgets.LabelWidget;
-    const Label = () => (
+    const Label = props => (
       <Widget
+        {...props}
         key={key}
         hasError={false}
+        hasTitle
+        toggleable={false}
         style={[first ? styles.labelTop : styles.label, gridItem.style]}
       >
         {gridItem.children}


### PR DESCRIPTION
**Summary**
New toggleable ui property `ui:toggleable` that allow the user to enable/disable fields.

This PR fixes/implements the following **bugs/features**

* [ ] The toggleable property adds a checkbox right next to the title
allowing the user to enable and disable the field by clicking
on that checkbox
* [ ] Disabled field values are ommitted upon submission
* [ ] Fixed the number field that wasn't allowing numbers over 1000

**Test plan (required)**

<img width="175" alt="Screen Shot 2019-04-16 at 6 38 30 PM" src="https://user-images.githubusercontent.com/4266269/56254766-ee2f5e80-6076-11e9-8d88-c4a92cd77acc.png">
<img width="178" alt="Screen Shot 2019-04-16 at 6 38 25 PM" src="https://user-images.githubusercontent.com/4266269/56254767-eec7f500-6076-11e9-8258-adc1f1a4b544.png">

**Closing issues**

Close CareLuLu/react-native-web-jsonschema-form#4 