### PR TITLE
feat(autocompleteWidget): add item param to AutocompleteWidget onSelect prop

### DIFF
--- a/src/widgets/AutocompleteWidget.js
+++ b/src/widgets/AutocompleteWidget.js
@@ -18,7 +18,7 @@ const allowedAttributes = [
 const AutocompleteWidget = withHandlers({
   onSelect: ({ onChange, onSelect, name }) => (value, item) => {
     if (isFunction(onSelect)) {
-      return onSelect(value, item);
+      onSelect(value, item);
     }
     return onChange(value, name);
   },

--- a/src/widgets/AutocompleteWidget.js
+++ b/src/widgets/AutocompleteWidget.js
@@ -16,9 +16,9 @@ const allowedAttributes = [
 ];
 
 const AutocompleteWidget = withHandlers({
-  onSelect: ({ onChange, onSelect, name }) => (value) => {
+  onSelect: ({ onChange, onSelect, name }) => (value, item) => {
     if (isFunction(onSelect)) {
-      return onSelect(value);
+      return onSelect(value, item);
     }
     return onChange(value, name);
   },


### PR DESCRIPTION
**Summary**
Add `item` parameter to `onSelect` prop in AutocompleteWidget.

This PR fixes/implements the following **bugs/features**

* [x] Pass item prop to `onSelect` prop in Autocomplete component

**Test Plan**

1. Use `autocomplete` as widget.
2. Add the following props
```
'ui:widget': 'autocomplete',
'ui:widgetProps': {
  items: () => ([{id: 1, name: 'one'}, {id: 2, name: 'two'}]),
  getItemValue: item => item.name,
  onSelect: (name, item) => console.log(item),
}
```
3. Start typing and select any item, you should see the item object in console.

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
closes #30
