### PR TITLE
feat(submit): get values before submitting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-web-jsonschema-form",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": false,
   "main": "index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { StyleSheet, Platform } from 'react-native';
+import { StyleSheet, Platform, Keyboard } from 'react-native';
 import {
   set,
   get,
@@ -317,22 +317,27 @@ class JsonSchemaForm extends React.Component {
   };
 
   onSubmit = () => {
-    const { metas, values } = this.state;
-    const { onSubmit, filterEmptyValues } = this.props;
-    let nextValues = this.filterDisabled(values, metas);
-    if (filterEmptyValues) {
-      nextValues = this.filterEmpty(nextValues);
+    if (Platform.OS !== 'web') {
+      Keyboard.dismiss();
     }
-    const event = new FormEvent('submit', { values: nextValues });
-    this.run(onSubmit(event), (response) => {
-      if (!event.isDefaultPrevented()) {
-        this.onSuccess(response);
+    setTimeout(() => {
+      const { metas, values } = this.state;
+      const { onSubmit, filterEmptyValues } = this.props;
+      let nextValues = this.filterDisabled(values, metas);
+      if (filterEmptyValues) {
+        nextValues = this.filterEmpty(nextValues);
       }
-    }, (errorSchema) => {
-      if (!event.isDefaultPrevented()) {
-        this.onError(errorSchema);
-      }
-    });
+      const event = new FormEvent('submit', { values: nextValues });
+      this.run(onSubmit(event), (response) => {
+        if (!event.isDefaultPrevented()) {
+          this.onSuccess(response);
+        }
+      }, (errorSchema) => {
+        if (!event.isDefaultPrevented()) {
+          this.onError(errorSchema);
+        }
+      });
+    }, Platform.OS !== 'web' ? 50 : 0);
   };
 
   onSuccess = (response) => {

--- a/src/widgets/TextInputWidget.js
+++ b/src/widgets/TextInputWidget.js
@@ -144,6 +144,13 @@ class TextInputWidget extends React.Component {
     this.input = input;
   };
 
+  onKeyPress = (event) => {
+    const { key } = event.nativeEvent;
+    if (key === 'ArrowUp' || key === 'ArrowDown') {
+      this.scrolled = true;
+    }
+  };
+
   onChangeText = (nextText) => {
     const { onChangeText } = this.props;
     const nextValue = this.parse(nextText);
@@ -155,22 +162,24 @@ class TextInputWidget extends React.Component {
   };
 
   onContentSizeChange = () => {
-    this.contentSize = true;
+    this.scrolled = true;
   };
 
   onBlur = (...args) => {
-    if (this.contentSize && Platform.OS === 'web' && this.input) {
+    const {
+      name,
+      value,
+      onBlur,
+      onChange,
+      changeOnblur,
+      multiline,
+    } = this.props;
+
+    if (this.scrolled && Platform.OS === 'web' && this.input && multiline) {
       this.input.focus();
     } else {
       this.setState({ autoFocus: false });
       const { text } = this.state;
-      const {
-        name,
-        value,
-        onBlur,
-        onChange,
-        changeOnblur,
-      } = this.props;
       const nextValue = this.parse(text);
       if (onBlur) {
         onBlur(...args);
@@ -182,7 +191,7 @@ class TextInputWidget extends React.Component {
   };
 
   onFocus = (...args) => {
-    this.contentSize = false;
+    this.scrolled = false;
     this.setState({ autoFocus: true });
     const { onFocus } = this.props;
     if (onFocus) {
@@ -266,6 +275,7 @@ class TextInputWidget extends React.Component {
         onRef={this.onRef}
         onBlur={this.onBlur}
         onFocus={this.onFocus}
+        onKeyPress={this.onKeyPress}
         onChangeText={this.onChangeText}
         onSubmitEditing={multiline ? noop : this.onSubmitEditing}
         onContentSizeChange={this.onContentSizeChange}

--- a/src/widgets/TextInputWidget.js
+++ b/src/widgets/TextInputWidget.js
@@ -1,14 +1,10 @@
-import React, { useRef, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { StyleSheet, Platform } from 'react-native';
 import { noop, isString, isFunction } from 'lodash';
 import TextInput from 'react-native-web-ui-components/TextInput';
 import StylePropType from 'react-native-web-ui-components/StylePropType';
-import {
-  isEmpty,
-  formatMask,
-  useAutoFocus,
-} from '../utils';
+import { isEmpty, formatMask } from '../utils';
 
 const styles = StyleSheet.create({
   defaults: {
@@ -21,16 +17,6 @@ const styles = StyleSheet.create({
     marginBottom: 0,
   },
 });
-
-const parser = ({ mask, textParser }) => (text) => {
-  if (!mask) {
-    return textParser(text);
-  }
-  if (isFunction(mask)) {
-    return textParser(mask(text, 'out'));
-  }
-  return textParser(formatMask(text, mask));
-};
 
 const getTextValue = ({ mask, value }) => {
   let textValue = '';
@@ -46,205 +32,249 @@ const getTextValue = ({ mask, value }) => {
   return textValue;
 };
 
-const useTextInputHandlers = (props) => {
-  const {
-    onChange,
-    value,
-    name,
-    mask,
-    uiSchema,
-    onSubmit,
-    multiline,
-    textParser,
-    onChangeText,
-    update,
-    renderId,
-    register,
-    changeOnblur,
-  } = props;
+class TextInputWidget extends React.Component {
+  static propTypes = {
+    update: PropTypes.oneOfType([PropTypes.shape(), PropTypes.string]).isRequired,
+    renderId: PropTypes.number.isRequired,
+    name: PropTypes.string.isRequired,
+    uiSchema: PropTypes.shape().isRequired,
+    hasError: PropTypes.bool.isRequired,
+    style: StylePropType,
+    mask: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+    onBlur: PropTypes.func,
+    onFocus: PropTypes.func,
+    onChange: PropTypes.func,
+    onSubmit: PropTypes.func,
+    focus: PropTypes.string,
+    value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    placeholder: PropTypes.string,
+    readonly: PropTypes.bool,
+    disabled: PropTypes.bool,
+    secureTextEntry: PropTypes.bool,
+    keyboardType: PropTypes.string,
+    multiline: PropTypes.bool,
+    numberOfLines: PropTypes.number,
+    auto: PropTypes.bool,
+    textParser: PropTypes.func,
+    Input: PropTypes.elementType,
+    inputProps: PropTypes.shape(),
+    onChangeText: PropTypes.func,
+    register: PropTypes.func,
+    changeOnblur: PropTypes.bool,
+  };
 
-  const textValue = getTextValue(props);
-  if (value !== null && value !== undefined && mask) {
-    const maskedValue = textParser(textValue);
-    if (value !== maskedValue) {
-      setTimeout(() => onChange(maskedValue, name, {
-        silent: true,
-      }));
+  static defaultProps = {
+    style: styles.empty,
+    mask: null,
+    onBlur: noop,
+    onFocus: noop,
+    onChange: noop,
+    onSubmit: noop,
+    focus: null,
+    value: null,
+    placeholder: '',
+    readonly: false,
+    disabled: false,
+    secureTextEntry: false,
+    keyboardType: 'default',
+    multiline: false,
+    numberOfLines: 1,
+    auto: false,
+    textParser: value => value,
+    Input: TextInput,
+    inputProps: {},
+    onChangeText: null,
+    register: noop,
+    changeOnblur: true,
+  };
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    const state = {};
+
+    const { update, value, renderId } = nextProps;
+    const { valueProp, renderIdProp } = prevState;
+
+    if (value !== valueProp) {
+      state.valueProp = value;
     }
+    if (renderId !== renderIdProp) {
+      state.renderIdProp = renderId;
+    }
+    if (update === 'all' && value !== valueProp && renderId !== renderIdProp) {
+      state.text = getTextValue(nextProps);
+    }
+    if (!Object.keys(state).length) {
+      return null;
+    }
+    return state;
   }
 
-  const [text, setText] = useState(textValue);
-  const [valueProp, setValueProp] = useState(value);
-  const [renderIdProp, setRenderIdProp] = useState(update);
+  constructor(props) {
+    super(props);
+    const { value, renderId, uiSchema } = props;
 
-  register(setText);
+    const text = getTextValue(props);
+    this.selection = {
+      start: text.length,
+      end: text.length,
+    };
 
-  const adjustments = [];
-  if (value !== valueProp) {
-    adjustments.push(() => setValueProp(value));
-  }
-  if (renderId !== renderIdProp) {
-    adjustments.push(() => setRenderIdProp(renderId));
-  }
-
-  let currentText = text;
-  if (update === 'all' && adjustments.length === 2) {
-    currentText = getTextValue(props);
-    adjustments.push(() => setText(currentText));
+    this.state = {
+      text,
+      valueProp: value,
+      renderIdProp: renderId,
+      autoFocus: !!uiSchema['ui:autofocus'],
+    };
   }
 
-  if (adjustments.length) {
-    setTimeout(() => adjustments.map(adjust => adjust()));
-  }
+  parse = (text) => {
+    const { mask, textParser } = this.props;
+    if (!mask) {
+      return textParser(text);
+    }
+    if (isFunction(mask)) {
+      return textParser(mask(text, 'out'));
+    }
+    return textParser(formatMask(text, mask));
+  };
 
-  const onChangeTextHandler = (nextText) => {
-    const nextValue = parser(props)(nextText);
-    const nextTextValue = getTextValue({ ...props, value: nextValue });
+  setText = text => this.setState({ text });
+
+  onRef = (input) => {
+    this.input = input;
+  };
+
+  onChangeText = (nextText) => {
+    const { onChangeText } = this.props;
+    const nextValue = this.parse(nextText);
+    const nextTextValue = getTextValue({ ...this.props, value: nextValue });
     if (onChangeText) {
       onChangeText(nextTextValue);
     }
-    setText(nextTextValue);
+    this.setText(nextTextValue);
   };
 
-  const onBlur = () => {
-    const nextValue = parser(props)(currentText);
-    if (changeOnblur && nextValue !== value) {
-      onChange(nextValue, name);
+  onContentSizeChange = () => {
+    this.contentSize = true;
+  };
+
+  onBlur = (...args) => {
+    if (this.contentSize && Platform.OS === 'web' && this.input) {
+      this.input.focus();
+    } else {
+      this.setState({ autoFocus: false });
+      const { text } = this.state;
+      const {
+        name,
+        value,
+        onBlur,
+        onChange,
+        changeOnblur,
+      } = this.props;
+      const nextValue = this.parse(text);
+      if (onBlur) {
+        onBlur(...args);
+      }
+      if (changeOnblur && nextValue !== value) {
+        onChange(nextValue, name);
+      }
     }
   };
 
-  const onSubmitEditing = () => {
-    const nextValue = parser(props)(currentText);
+  onFocus = (...args) => {
+    this.contentSize = false;
+    this.setState({ autoFocus: true });
+    const { onFocus } = this.props;
+    if (onFocus) {
+      onFocus(...args);
+    }
+  };
+
+  onSubmitEditing = () => {
+    const { text } = this.state;
+    const {
+      name,
+      value,
+      onChange,
+      onSubmit,
+    } = this.props;
+    const nextValue = this.parse(text);
     if (nextValue !== value) {
       onChange(nextValue, name);
     }
     onSubmit();
   };
 
-  const selection = useRef();
-  if (!selection.current || adjustments.length === 3) {
-    selection.current = {
-      start: currentText.length,
-      end: currentText.length,
+  onSelectionChange = (event) => {
+    this.selection = {
+      start: event.nativeEvent.selection.start,
+      end: event.nativeEvent.selection.end,
     };
-  }
-
-  const autoFocusParams = useAutoFocus({ ...props, onBlur });
-
-  const params = {
-    ...autoFocusParams,
-    onChangeText: onChangeTextHandler,
-    onSubmitEditing: multiline ? noop : onSubmitEditing,
-    value: isEmpty(currentText) ? (uiSchema['ui:emptyValue'] || '') : currentText,
   };
 
-  if (!mask && Platform.OS === 'web') {
-    params.selection = selection.current;
-    params.onSelectionChange = (event) => {
-      selection.current = {
-        start: event.nativeEvent.selection.start,
-        end: event.nativeEvent.selection.end,
-      };
-    };
+  render() {
+    const {
+      name,
+      auto,
+      style,
+      multiline,
+      hasError,
+      disabled,
+      readonly,
+      placeholder,
+      keyboardType,
+      numberOfLines,
+      secureTextEntry,
+      Input,
+      inputProps,
+      register,
+      uiSchema,
+      mask,
+    } = this.props;
+
+    const { text, autoFocus } = this.state;
+
+    register(this.setText);
+
+    const currentStyle = [
+      styles.defaults,
+      auto ? styles.auto : styles.fullWidth,
+      style,
+    ];
+
+    const selectionProps = {};
+    if (!mask && Platform.OS === 'web') {
+      selectionProps.selection = this.selection;
+      selectionProps.onSelectionChange = this.onSelectionChange;
+    }
+
+    return (
+      <Input
+        key={name}
+        hasError={hasError}
+        disabled={disabled}
+        readonly={readonly}
+        autoFocus={autoFocus}
+        autoCapitalize="none"
+        className="TextInput__widget"
+        style={currentStyle}
+        multiline={multiline}
+        numberOfLines={numberOfLines}
+        keyboardType={Platform.OS !== 'web' ? keyboardType : undefined}
+        placeholder={placeholder}
+        secureTextEntry={secureTextEntry}
+        onRef={this.onRef}
+        onBlur={this.onBlur}
+        onFocus={this.onFocus}
+        onChangeText={this.onChangeText}
+        onSubmitEditing={multiline ? noop : this.onSubmitEditing}
+        onContentSizeChange={this.onContentSizeChange}
+        value={isEmpty(text) ? (uiSchema['ui:emptyValue'] || '') : text}
+        {...selectionProps}
+        {...inputProps}
+      />
+    );
   }
-
-  return params;
-};
-
-const TextInputWidget = (props) => {
-  const params = useTextInputHandlers(props);
-
-  const {
-    name,
-    auto,
-    style,
-    multiline,
-    hasError,
-    disabled,
-    readonly,
-    placeholder,
-    keyboardType,
-    numberOfLines,
-    secureTextEntry,
-    Input,
-    inputProps,
-  } = props;
-
-  const currentStyle = [
-    styles.defaults,
-    auto ? styles.auto : styles.fullWidth,
-    style,
-  ];
-
-  return (
-    <Input
-      {...params}
-      key={name}
-      hasError={hasError}
-      disabled={disabled}
-      readonly={readonly}
-      autoCapitalize="none"
-      className="TextInput__widget"
-      style={currentStyle}
-      multiline={multiline}
-      numberOfLines={numberOfLines}
-      keyboardType={Platform.OS !== 'web' ? keyboardType : undefined}
-      placeholder={placeholder}
-      secureTextEntry={secureTextEntry}
-      {...inputProps}
-    />
-  );
-};
-
-TextInputWidget.propTypes = {
-  name: PropTypes.string.isRequired,
-  uiSchema: PropTypes.shape().isRequired,
-  hasError: PropTypes.bool.isRequired,
-  style: StylePropType,
-  mask: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-  onFocus: PropTypes.func,
-  onChange: PropTypes.func,
-  onSubmit: PropTypes.func,
-  focus: PropTypes.string,
-  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  placeholder: PropTypes.string,
-  readonly: PropTypes.bool,
-  disabled: PropTypes.bool,
-  secureTextEntry: PropTypes.bool,
-  keyboardType: PropTypes.string,
-  multiline: PropTypes.bool,
-  numberOfLines: PropTypes.number,
-  auto: PropTypes.bool,
-  textParser: PropTypes.func,
-  Input: PropTypes.elementType,
-  inputProps: PropTypes.shape(),
-  onChangeText: PropTypes.func,
-  register: PropTypes.func,
-  changeOnblur: PropTypes.bool,
-};
-
-TextInputWidget.defaultProps = {
-  style: styles.empty,
-  mask: null,
-  onFocus: noop,
-  onChange: noop,
-  onSubmit: noop,
-  focus: null,
-  value: null,
-  placeholder: '',
-  readonly: false,
-  disabled: false,
-  secureTextEntry: false,
-  keyboardType: 'default',
-  multiline: false,
-  numberOfLines: 1,
-  auto: false,
-  textParser: value => value,
-  Input: TextInput,
-  inputProps: {},
-  onChangeText: null,
-  register: noop,
-  changeOnblur: true,
-};
+}
 
 export default TextInputWidget;


### PR DESCRIPTION
**Summary**

On iOS and Android, fields based on TextInput were not returning the values when calling `form.submit()`. And on the Web, `multiline` fields were losing focus when the scroll moved.

This PR fixes/implements the following **bugs/features**

* [x] Return values on TextInput when `form.submit()` is called.
* [x] Do not lose focus when moving the scroll on multiline inputs.

**Test plan (required)**

1. Try to login on mobile. Type the email, type the password and click on Log In.
2. Press enter until the scroll moves (5 times for the height of 80).

**Closing issues**

Fixes #51 and #53
