### PR TITLE
feat(textWidget): add customName prop

### DIFF
--- a/src/widgets/TextWidget/index.js
+++ b/src/widgets/TextWidget/index.js
@@ -40,7 +40,7 @@ class TextWidget extends React.Component {
   static propTypes = {
     theme: PropTypes.shape().isRequired,
     name: PropTypes.string.isRequired,
-    customName: PropTypes.func,
+    textParser: PropTypes.func,
     onChange: PropTypes.func.isRequired,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     to: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
@@ -61,7 +61,7 @@ class TextWidget extends React.Component {
     value: null,
     to: null,
     auto: false,
-    customName: null,
+    textParser: value => (value !== null && value !== undefined ? value : ''),
     style: null,
     textStyle: null,
     textContainerStyle: null,
@@ -139,7 +139,7 @@ class TextWidget extends React.Component {
       SaveComponent,
       CancelComponent,
       children,
-      customName,
+      textParser,
     } = this.props;
     const { editing, displayValue, value } = this.state;
     let href = null;
@@ -197,9 +197,7 @@ class TextWidget extends React.Component {
                     textStyle,
                   ]}
                 >
-                  {
-                    (value !== null && value !== undefined) ? (customName ? customName(value) : value) : '' // eslint-disable-line
-                  }
+                  { textParser(value) }
                 </Link>
               )}
               {this.renderChildren(children)}

--- a/src/widgets/TextWidget/index.js
+++ b/src/widgets/TextWidget/index.js
@@ -40,6 +40,7 @@ class TextWidget extends React.Component {
   static propTypes = {
     theme: PropTypes.shape().isRequired,
     name: PropTypes.string.isRequired,
+    customName: PropTypes.func,
     onChange: PropTypes.func.isRequired,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     to: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
@@ -60,6 +61,7 @@ class TextWidget extends React.Component {
     value: null,
     to: null,
     auto: false,
+    customName: null,
     style: null,
     textStyle: null,
     textContainerStyle: null,
@@ -137,6 +139,7 @@ class TextWidget extends React.Component {
       SaveComponent,
       CancelComponent,
       children,
+      customName,
     } = this.props;
     const { editing, displayValue, value } = this.state;
     let href = null;
@@ -194,7 +197,9 @@ class TextWidget extends React.Component {
                     textStyle,
                   ]}
                 >
-                  {value !== null && value !== undefined ? value : ''}
+                  {
+                    (value !== null && value !== undefined) ? (customName ? customName(value) : value) : '' // eslint-disable-line
+                  }
                 </Link>
               )}
               {this.renderChildren(children)}


### PR DESCRIPTION
** Related Issues **
https://github.com/CareLuLu/v3-app/issues/768

**Summary**

Add customeName prop to the TextWidget

This PR fixes/implements the following **bugs/features**

* [ ] Add customName prop

**Test plan (required)**
1. Login as Admin.
2. Go to /admin/9/schools/10/edit.
3. Go to the Onboarding section.
4. Upload a document. You should see something similar to this when document is uploaded.
<img width="878" alt="Screen Shot 2020-03-11 at 10 34 18 AM" src="https://user-images.githubusercontent.com/54905905/76362910-d2b3fd00-6386-11ea-9ce8-9d563e0eefc9.png">

**Code formatting**
NA

**Closing issues**
closes #96
