### PR TITLE
fix(phoneWidget): properly format phone numbers with hyphens and spaces

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -391,16 +391,11 @@ const maskOptions = {
   '*': /^.$/,
 };
 
-export const formatMask = (value, mask) => {
-  let text = (value === null || value === undefined) ? '' : `${value}`;
+const defaultParser = value => ((value === null || value === undefined) ? '' : `${value}`);
 
-  if (mask === '(999) 999-9999') {
-    if (text.indexOf('-') || text.indexOf(' ')) {
-      // remove hyphen and space characters
-      text = text.replace('-', '').replace(' ', '');
-    }
-  }
-
+export const formatMask = (value, mask, maskParser) => {
+  const parse = maskParser || defaultParser;
+  const text = parse(value);
   let result = '';
   let cursorText = 0;
   let cursorMask = 0;

--- a/src/utils.js
+++ b/src/utils.js
@@ -392,7 +392,15 @@ const maskOptions = {
 };
 
 export const formatMask = (value, mask) => {
-  const text = (value === null || value === undefined) ? '' : `${value}`;
+  let text = (value === null || value === undefined) ? '' : `${value}`;
+
+  if (mask === '(999) 999-9999') {
+    if (text.indexOf('-') || text.indexOf(' ')) {
+      // remove hyphen and space characters
+      text = text.replace('-', '').replace(' ', '');
+    }
+  }
+
   let result = '';
   let cursorText = 0;
   let cursorMask = 0;

--- a/src/widgets/PhoneWidget.js
+++ b/src/widgets/PhoneWidget.js
@@ -2,11 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import TextInputWidget from './TextInputWidget';
 
-const PhoneWidget = props => <TextInputWidget {...props} />;
+const maskParser = (value) => {
+  const text = (value === null || value === undefined) ? '' : `${value}`;
+  return text.replace(/[^0-9]/g, '');
+};
+
+const PhoneWidget = props => <TextInputWidget {...props} maskParser={maskParser} />;
 
 PhoneWidget.propTypes = {
   mask: PropTypes.string,
   keyboardType: PropTypes.string,
+  maskParser: PropTypes.func.isRequired,
 };
 
 PhoneWidget.defaultProps = {

--- a/src/widgets/TextInputWidget.js
+++ b/src/widgets/TextInputWidget.js
@@ -18,11 +18,11 @@ const styles = StyleSheet.create({
   },
 });
 
-const getTextValue = ({ mask, value }) => {
+const getTextValue = ({ mask, value, maskParser }) => {
   let textValue = '';
   if (value !== null && value !== undefined) {
     if (isString(mask)) {
-      textValue = formatMask(`${value}`, mask);
+      textValue = formatMask(`${value}`, mask, maskParser);
     } else if (isFunction(mask)) {
       textValue = mask(`${value}`, 'in');
     } else {
@@ -61,6 +61,7 @@ class TextInputWidget extends React.Component {
     onChangeText: PropTypes.func,
     register: PropTypes.func,
     changeOnBlur: PropTypes.bool,
+    maskParser: PropTypes.func,
   };
 
   static defaultProps = {
@@ -86,6 +87,7 @@ class TextInputWidget extends React.Component {
     onChangeText: null,
     register: noop,
     changeOnBlur: true,
+    maskParser: null,
   };
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -128,14 +130,14 @@ class TextInputWidget extends React.Component {
   }
 
   parse = (text) => {
-    const { mask, textParser } = this.props;
+    const { mask, textParser, maskParser } = this.props;
     if (!mask) {
       return textParser(text);
     }
     if (isFunction(mask)) {
       return textParser(mask(text, 'out'));
     }
-    return textParser(formatMask(text, mask));
+    return textParser(formatMask(text, mask, maskParser));
   };
 
   setText = text => this.setState({ text });


### PR DESCRIPTION
**Summary**

If Admin copies and pastes a phone number in a specific format, the system should recognize it and convert it to our own format. For instance, if admin plugs in “571-249- 5751” with hyphens, the system should know to auto-convert that to 571 249 5751 instead of “(571) 24-95”.

This PR fixes/implements the following **bugs/features**

* [ ] Fix format of phone numbers if input have hyphens and/or spaces

**Test plan (required)**
1. Login as Admin
2. Go to `/dashboard/10/reviews/list`
3. Copy paste or type in `571-249- 5751`
4. It should return `(571) 249-5751` properly

**Code formatting**
NA

**Closing issues**
closes #105
