### PR TITLE
fix(fileWidget): prevent click event if target has input element in it

### DIFF
--- a/src/widgets/FileWidget/index.js
+++ b/src/widgets/FileWidget/index.js
@@ -534,7 +534,10 @@ const useOnAreaClick = ({ dragging }) => (event) => {
 
 const useOnClick = ({ propertySchema }) => (event) => {
   const fn = propertySchema.type === 'array' ? 'preventDefault' : 'stopPropagation';
-  if (event.nativeEvent.target.tagName === 'INPUT') {
+  if (
+    event.nativeEvent.target.tagName === 'INPUT'
+    || event.nativeEvent.target.querySelectorAll('input').length > 0
+  ) {
     event[fn]();
   }
   if (isField(event.nativeEvent.target, handleRegex)) {


### PR DESCRIPTION
**Summary**

Prevent file window popup when clicking on an input type element.

This PR fixes/implements the following **bugs/features**

* [ ] Add extra check to see if clicked element contains input tag