### PR TITLE
fix(scheduleWidget): inconsistency in times attribute beyond index 8

### DIFF
--- a/src/widgets/ScheduleWidget/index.js
+++ b/src/widgets/ScheduleWidget/index.js
@@ -110,7 +110,7 @@ const getProps = (props) => {
         ...get(uiSchema, ['items', timesAttribute], {}),
         'ui:title': false,
         'ui:widget': 'timeRange',
-        'ui:widgetProps': times(7, i => ({
+        'ui:widgetProps': times(100, i => ({
           ...get(uiSchema, ['items', timesAttribute, 'ui:widgetProps'], {}),
           encoder: 'string',
           header: i === 0,


### PR DESCRIPTION
**Summary**

Fix inconsistency in times attribute beyond index 8. This also cause inconsistency to the actual value passed to the form causing a problem during submission.

This PR fixes/implements the following **bugs/features**

* [X] Increased number of time attributes to get a default props

**Test plan (required)**

- Use schedule widget and set `addable: true`
- Add items until you have 8 or more items
- You should see the same format in every item

#### Before
<img width="838" alt="Screenshot 2020-07-22 at 8 37 51 AM" src="https://user-images.githubusercontent.com/54905174/88120961-e1dd6e00-cbf6-11ea-8914-73c8ac3e9304.png">

#### After
<img width="813" alt="Screenshot 2020-07-22 at 8 35 54 AM" src="https://user-images.githubusercontent.com/54905174/88120973-edc93000-cbf6-11ea-815c-bbb2e8531c80.png">

