### PR TITLE
feat(file): add ability to remove uploaded file

### DIFF
--- a/src/widgets/ArrayWidget/index.js
+++ b/src/widgets/ArrayWidget/index.js
@@ -100,7 +100,7 @@ const getProps = (props) => {
       || options.minimumNumberOfItems === null
     ) ? 1 : options.minimumNumberOfItems,
     addLabel: options.addLabel || `Add ${formatTitle(title)}`,
-    removeLabel: options.removeLabel || 'Remove',
+    removeLabel: options.removeLabel || 'Delete',
     orderLabel: options.orderLabel || <Icon name="th" />,
     removeStyle: options.removeStyle,
     orderStyle: options.orderStyle,

--- a/src/widgets/FileWidget/RemoveHandle.js
+++ b/src/widgets/FileWidget/RemoveHandle.js
@@ -9,14 +9,10 @@ const styles = StyleSheet.create({
     paddingLeft: 10,
     paddingTop: 11,
   },
-  fullWidth: {
-    width: '100%',
-  },
 });
 
 const RemoveHandle = ({
   theme,
-  auto,
   onRemovePress,
   removeLabel,
   removeStyle,
@@ -24,13 +20,9 @@ const RemoveHandle = ({
 }) => (
   <Link
     {...props}
-    auto={auto}
+    auto
     onPress={onRemovePress}
-    style={[
-      styles.handle,
-      auto ? null : styles.fullWidth,
-      removeStyle,
-    ]}
+    style={[styles.handle, removeStyle]}
     type={theme.colors.primary}
   >
     {removeLabel}
@@ -38,7 +30,6 @@ const RemoveHandle = ({
 );
 
 RemoveHandle.propTypes = {
-  auto: PropTypes.bool,
   theme: PropTypes.shape().isRequired,
   onRemovePress: PropTypes.func.isRequired,
   removeLabel: PropTypes.node.isRequired,
@@ -47,7 +38,6 @@ RemoveHandle.propTypes = {
 
 RemoveHandle.defaultProps = {
   removeStyle: null,
-  auto: false,
 };
 
 export default RemoveHandle;

--- a/src/widgets/FileWidget/RemoveHandle.js
+++ b/src/widgets/FileWidget/RemoveHandle.js
@@ -9,10 +9,14 @@ const styles = StyleSheet.create({
     paddingLeft: 10,
     paddingTop: 11,
   },
+  fullWidth: {
+    width: '100%',
+  },
 });
 
 const RemoveHandle = ({
   theme,
+  auto,
   onRemovePress,
   removeLabel,
   removeStyle,
@@ -20,9 +24,13 @@ const RemoveHandle = ({
 }) => (
   <Link
     {...props}
-    auto
+    auto={auto}
     onPress={onRemovePress}
-    style={[styles.handle, removeStyle]}
+    style={[
+      styles.handle,
+      auto ? null : styles.fullWidth,
+      removeStyle,
+    ]}
     type={theme.colors.primary}
   >
     {removeLabel}
@@ -30,6 +38,7 @@ const RemoveHandle = ({
 );
 
 RemoveHandle.propTypes = {
+  auto: PropTypes.bool,
   theme: PropTypes.shape().isRequired,
   onRemovePress: PropTypes.func.isRequired,
   removeLabel: PropTypes.node.isRequired,
@@ -38,6 +47,7 @@ RemoveHandle.propTypes = {
 
 RemoveHandle.defaultProps = {
   removeStyle: null,
+  auto: false,
 };
 
 export default RemoveHandle;

--- a/src/widgets/FileWidget/index.js
+++ b/src/widgets/FileWidget/index.js
@@ -127,6 +127,8 @@ const getProps = (props) => {
   } = props;
 
   const dropzoneStyle = [];
+  const options = uiSchema['ui:options'] || {};
+  const removable = options.removable !== false;
   let isMultiple = multiple;
   let adjustedNameAttribute;
   let adjustedPathAttribute;
@@ -141,9 +143,9 @@ const getProps = (props) => {
   let adjustedEditComponent = EditComponent;
   let adjustedProgressComponent = ProgressComponent;
   let adjustedRemoveComponent = RemoveComponent;
-  let adjustedUploadComponent = UploadComponent;
   let adjustedRemoveStyle = removeStyle;
   let adjustedRemoveLabel = removeLabel;
+  let adjustedUploadComponent = UploadComponent;
   let adjustedUploadStyle = uploadStyle;
   let adjustedUploadLabel = uploadLabel;
 
@@ -157,10 +159,6 @@ const getProps = (props) => {
       adjustedRemoveComponent
       || (uiSchema['ui:options'] && uiSchema['ui:options'].RemoveComponent)
     );
-    adjustedUploadComponent = (
-      adjustedUploadComponent
-      || (uiSchema['ui:options'] && uiSchema['ui:options'].UploadComponent)
-    );
     adjustedRemoveStyle = (
       adjustedRemoveStyle
       || (uiSchema['ui:options'] && uiSchema['ui:options'].removeStyle)
@@ -168,6 +166,10 @@ const getProps = (props) => {
     adjustedRemoveLabel = (
       adjustedRemoveLabel
       || (uiSchema['ui:options'] && uiSchema['ui:options'].removeLabel)
+    );
+    adjustedUploadComponent = (
+      adjustedUploadComponent
+      || (uiSchema['ui:options'] && uiSchema['ui:options'].UploadComponent)
     );
     adjustedUploadStyle = (
       adjustedUploadStyle
@@ -209,14 +211,14 @@ const getProps = (props) => {
   if (!adjustedRemoveComponent) {
     adjustedRemoveComponent = RemoveHandle;
   }
-  if (!adjustedUploadComponent) {
-    adjustedUploadComponent = UploadHandle;
-  }
   if (adjustedRemoveStyle === undefined) {
     adjustedRemoveStyle = null;
   }
   if (adjustedRemoveLabel === undefined) {
     adjustedRemoveLabel = 'Delete';
+  }
+  if (!adjustedUploadComponent) {
+    adjustedUploadComponent = UploadHandle;
   }
   if (adjustedUploadStyle === undefined) {
     adjustedUploadStyle = null;
@@ -357,6 +359,7 @@ const getProps = (props) => {
   return {
     ...props,
     title,
+    removable,
     fileSchema,
     dropzoneStyle,
     propertyUiSchema,
@@ -513,9 +516,9 @@ const useOnRemove = ({
   name,
   value,
   onChange,
-  removableFile,
+  removable,
 }) => {
-  const canRemove = value && removableFile;
+  const canRemove = value && removable;
   const onRemove = () => {
     const nextValue = null;
     const nextMeta = {};
@@ -827,7 +830,6 @@ FileWidget.propTypes = {
   ProgressComponent: PropTypes.elementType,
   downloadable: PropTypes.bool,
   downloadBasepath: PropTypes.string,
-  removableFile: PropTypes.bool,
 };
 
 FileWidget.defaultProps = {
@@ -847,7 +849,6 @@ FileWidget.defaultProps = {
   ProgressComponent: undefined,
   downloadable: undefined,
   downloadBasepath: undefined,
-  removableFile: false,
 };
 
 export default FileWidget;


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [X] Ability to delete uploaded file in file widget

**Test plan (required)**

Use the `file` widget with string type field like below and set `removableFile` in `widgetProps`

```javascript
const schema = {
  title: 'Files',
  type: 'object',
  properties: {
    uploadOnly: {
      type: 'string',
      title: 'Upload Only',
    },
    string: {
      type: 'string',
      title: 'String',
    },
    arrayObject: {
      type: 'array',
      title: 'Array - object',
      items: {
        type: 'object',
        properties: {
          filename: {
            type: 'string',
          },
        },
      }
    },
    arrayString: {
      type: 'array',
      title: 'Array - String',
      items: {
        type: 'string',
      }
    },
  },
};

const uiSchema = {
  uploadOnly: {
    'ui:widget': 'file',
    'ui:options': {
      removable: false,
    },
  },
  string: {
    'ui:widget': 'file',
  },
  arrayObject: {
    items: {
      filename: {
        'ui:widget': 'file',
      },
    },
  },
  arrayString: {
    'ui:widget': 'file',
  },
};
```

![delete-widget2](https://user-images.githubusercontent.com/54905174/104763278-96201180-57a0-11eb-9a16-dd35685f06a5.gif)


**Closing issues**

Closes N/A. This PR will be closed by https://github.com/CareLuLu/v3-app/issues/1298
