### PR TITLE
chore: Add description to package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "react-native-web-jsonschema-form",
+  "description": "Render customizable forms using JSON schema for responsive websites and Expo apps (both Android and iOS).",
   "version": "4.0.0",
   "private": false,
   "main": "index.js",


### PR DESCRIPTION
**Summary**

While validating data in React Native Directory I have spotted that the package misses a description:

<img width="2426" height="458" alt="Screenshot 2025-09-18 at 09 59 31" src="https://github.com/user-attachments/assets/73f5bcd7-c103-4f74-a865-4fc65f565fc4" />

To fix that, I have copied over the first README sentence to the [`package.json` description field](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#description-1). 

This also should help with package discoverability in the npm registry.

**Test plan (required)**

N/A
